### PR TITLE
Add ForemanProviders::Logging so _log will work

### DIFF
--- a/lib/foreman_providers.rb
+++ b/lib/foreman_providers.rb
@@ -1,4 +1,5 @@
 require 'foreman_providers/engine'
+require 'foreman_providers/logging'
 
 module ForemanProviders
 end

--- a/lib/foreman_providers/logging.rb
+++ b/lib/foreman_providers/logging.rb
@@ -1,0 +1,7 @@
+module ForemanProviders
+  module Logging
+    def _log
+      Foreman::Logging.logger("foreman_providers")
+    end
+  end
+end


### PR DESCRIPTION
Lots of MIQ code assumes we have _log available, add a
ForemanProviders::Logging._log so that most of the standard calls to
_log will work.  This just wraps the standard forman plugin logger.