### PR TITLE
Fix the refresher class module location

### DIFF
--- a/app/models/providers/ems_refresh.rb
+++ b/app/models/providers/ems_refresh.rb
@@ -40,7 +40,8 @@ module Providers
               when t.respond_to?(:manager)               then t.manager
               else                                            t
               end
-        ems.class::Refresher
+
+        ems.refresher_klass
       end
 
       # Do the refreshes

--- a/app/models/providers/ems_refresh/refresher.rb
+++ b/app/models/providers/ems_refresh/refresher.rb
@@ -51,8 +51,7 @@ module Providers
           _log.info "#{log_ems_target} Refreshing target #{target.class} [#{target.name}] id [#{target.id}]...Complete"
         end
       rescue => e
-        _log.error("#{log_ems_target} Refresh failed")
-        _log.error(e.backtrace.join("\n"))
+        _log.error("#{log_ems_target} Refresh failed: #{e}\n#{e.backtrace.join("\n")}")
         _log.error("#{log_ems_target} Unable to perform refresh for the following targets:")
         targets.each do |target|
           target = target.first if target.kind_of?(Array)

--- a/app/models/providers/ext_management_system.rb
+++ b/app/models/providers/ext_management_system.rb
@@ -91,5 +91,9 @@ module Providers
       build_endpoint_by_role(options[:endpoint])
       build_authentication_by_role(options[:authentication])
     end
+
+    def refresher_klass
+      self.class.parent::Refresher
+    end
   end
 end


### PR DESCRIPTION
The refresher class used to be under the provider's class when the
provider was at e.g. Providers::Ovirt but now that the provider is at
Providers::Ovirt::Manager and the refresher is still at
Providers::Ovirt::Refresher we need to update the dynamic refresher
class location.