### PR TITLE
Create and destroy provider with compute_resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,48 @@
 # ForemanProviders
 
-*Introdction here*
+Adds ManageIQ Providers and Inventory to Foreman
 
 ## Installation
 
-See [How_to_Install_a_Plugin](http://projects.theforeman.org/projects/foreman/wiki/How_to_Install_a_Plugin)
-for how to install Foreman plugins
+Clone the provider plugins:
+
+```bash
+git clone https://github.com/agrare/foreman_providers.git
+git clone https://github.com/agrare/foreman_providers_infra.git
+git clone https://github.com/agrare/foreman_providers_ovirt.git
+```
+
+Add the provider plugins to your Foreman bundler.d/ directory:
+
+```bash
+echo 'gem "ovirt" # require the ovirt gem early to workaround issues with rbovirt
+gem "foreman_providers",      :path => "../foreman_providers"
+gem "foreman_providers_infra, :path => "../foreman_providers_infra"
+gem "foreman_providers_ovirt, :path => "../foreman_providers_ovirt"' > bundler.d/provider.rb
+```
+
+Update your foreman gems and database
+
+```bash
+bundle update
+bin/rails db:migrate
+```
 
 ## Usage
 
-*Usage here*
+Add a new Ovirt ComputeResource and a new Provider will be automatically created for you
+
+Refresh your provider inventory
+
+```bash
+bin/rails runner 'Providers::Ovirt::Manager.first.refresh'
+```
+
+This should automatically create managed hosts from the Ovirt Hosts and VMs in your inventory.
+
+Additionally there may be more VMs that aren't listed if they don't have an IP address that was detected.
+
+These VMs are in the `Providers::Infra::Vm` model, templates are in the `Providers::Infra::Template` model, and hosts in (wait for it) `Providers::Infra::Host`.
 
 ## TODO
 
@@ -21,7 +54,7 @@ Fork and send a Pull Request. Thanks!
 
 ## Copyright
 
-Copyright (c) *year* *your name*
+Copyright (c) 2018 Red Hat, Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/models/concerns/foreman_providers/compute_resource.rb
+++ b/app/models/concerns/foreman_providers/compute_resource.rb
@@ -10,9 +10,10 @@ module ForemanProviders
     def create_provider
       provider_klass = foreman_type_to_provider_type.constantize
 
-      ems = provider_klass.create!(:name => name, :hostname => URI(url).host)
-      ems.update_authentication(:default => {:userid => user, :password => password})
-      ems.default_endpoint.update_attributes(:verify_ssl => 0)
+      ems = provider_klass.new(:name => name)
+      ems.authentications << Providers::Authentication.new(:authtype => "default", :userid => user, :password => password)
+      ems.endpoints       << Providers::Endpoint.new(:role => "default", :hostname => URI(url).host, :verify_ssl => 0)
+      ems.save!
     end
 
     def destroy_provider

--- a/app/models/concerns/foreman_providers/compute_resource.rb
+++ b/app/models/concerns/foreman_providers/compute_resource.rb
@@ -17,7 +17,7 @@ module ForemanProviders
 
     def destroy_provider
       provider_klass = foreman_type_to_provider_type.constantize
-      provider_klass.find_by(:hostname => URI(url).host).try(:destroy)
+      provider_klass.find_by(:name => name).try(:destroy)
     end
 
     def foreman_type_to_provider_type

--- a/app/models/concerns/foreman_providers/compute_resource.rb
+++ b/app/models/concerns/foreman_providers/compute_resource.rb
@@ -1,0 +1,30 @@
+module ForemanProviders
+  module ComputeResource
+    extend ActiveSupport::Concern
+
+    included do
+      after_create :create_provider
+      before_destroy :destroy_provider
+    end
+
+    def create_provider
+      provider_klass = foreman_type_to_provider_type.constantize
+
+      ems = provider_klass.create!(:name => name, :hostname => URI(url).host)
+      ems.update_authentication(:default => {:userid => user, :password => password})
+      ems.default_endpoint.update_attributes(:verify_ssl => 0)
+    end
+
+    def destroy_provider
+      provider_klass = foreman_type_to_provider_type.constantize
+      provider_klass.find_by(:hostname => URI(url).host).try(:destroy)
+    end
+
+    def foreman_type_to_provider_type
+      case type
+      when "Foreman::Model::Ovirt"
+        "Providers::Ovirt::Manager"
+      end
+    end
+  end
+end

--- a/app/models/providers/ems_refresh/refresher.rb
+++ b/app/models/providers/ems_refresh/refresher.rb
@@ -81,7 +81,13 @@ module Providers
       end
 
       def post_refresh(ems, ems_refresh_start_time)
+        log_ems_target = format_ems_for_logging(ems)
+
         post_process_refresh_classes.each do |klass|
+          next unless klass.respond_to?(:post_refresh_ems)
+          _log.info("#{log_ems_target} Performing post-refresh operations for #{klass} instances...")
+          klass.post_refresh_ems(ems.id, ems_refresh_start_time)
+          _log.info("#{log_ems_target} Performing post-refresh operations for #{klass} instances...Complete")
         end
       end
 

--- a/app/models/providers/ems_refresh/save_inventory.rb
+++ b/app/models/providers/ems_refresh/save_inventory.rb
@@ -36,8 +36,8 @@ module Providers
                         []
                       end
 
-        child_keys = [:operating_system, :hardware, :custom_attributes, :snapshots, :advanced_settings, :labels, :tags]
-        extra_infra_keys = [:host, :ems_cluster, :storage, :storages, :storage_profile, :raw_power_state, :parent_vm]
+        child_keys       = [:operating_system, :hardware]
+        extra_infra_keys = [:hardware, :custom_attributes, :snapshots, :advanced_settings, :labels, :tags, :host, :ems_cluster, :storage, :storages, :storage_profile, :raw_power_state, :parent_vm]
         extra_cloud_keys = [
           :resource_group,
           :flavor,
@@ -123,7 +123,7 @@ module Providers
 
               #link_habtm(found, key_backup[:storages], :storages, Storage)
               #link_habtm(found, key_backup[:key_pairs], :key_pairs, ManageIQ::Providers::CloudManager::AuthKeyPair)
-              #save_child_inventory(found, key_backup, child_keys)
+              save_child_inventory(found, key_backup, child_keys)
 
               found.save!
               h[:id] = found.id
@@ -199,7 +199,7 @@ module Providers
         # Only set a value if we do not have one and we have not collected scan metadata.
         # Otherwise an ems may not contain the proper value and we do not want to overwrite
         # the value collected during our metadata scan.
-        return if parent.kind_of?(Vm) && !(parent.drift_states.size.zero? || parent.operating_system.nil? || parent.operating_system.product_name.blank?)
+        return if parent.kind_of?(Infra::Vm) && !(parent.operating_system.nil? || parent.operating_system.product_name.blank?)
 
         save_inventory_single(:operating_system, parent, hash)
       end


### PR DESCRIPTION
This will create a provider matching the CR record and allow for post_refresh tasks to create associated Host records from discovered Infra Hosts and Vms.

![screenshot from 2018-03-28 14-39-56](https://user-images.githubusercontent.com/12851112/38049952-8c048626-3297-11e8-9c35-ca24e05bb6d8.png)
