### PR TITLE
Actually load the mixin that it creates the provider.

### DIFF
--- a/lib/foreman_providers/engine.rb
+++ b/lib/foreman_providers/engine.rb
@@ -58,8 +58,7 @@ module ForemanProviders
     # Include concerns in this config.to_prepare block
     config.to_prepare do
       begin
-        Host::Managed.send(:include, ForemanProviders::HostExtensions)
-        HostsHelper.send(:include, ForemanProviders::HostsHelperExtensions)
+        Foreman::Model::Ovirt.include(ForemanProviders::ComputeResource)
       rescue => e
         Rails.logger.warn "ForemanProviders: skipping engine hook (#{e})"
       end


### PR DESCRIPTION
limit this to ovirt class ATM as other compute resources will fail.